### PR TITLE
Update test cases

### DIFF
--- a/tests/__snapshots__/main.test.ts.snap
+++ b/tests/__snapshots__/main.test.ts.snap
@@ -30,7 +30,7 @@ exports[`rebaser when a line is added packages matches the snapshot 1`] = `
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.36.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.1.5" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
@@ -86,7 +86,7 @@ exports[`rebaser when a solution has multiple conflicts packages matches the sna
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.6.23329.7" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />
@@ -118,7 +118,7 @@ exports[`rebaser when a the number of lines in the diff is uneven packages match
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0-preview.6.23329.7" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.0-preview.6.23329.11" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" Condition=" '$(IsTestProject)' != 'true' " />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" Condition=" '$(IsTestProject)' == 'true' " />
     <PackageVersion Include="Polly" Version="7.2.4" />

--- a/tests/fixtures/AddedLine/base/Directory.Packages.props
+++ b/tests/fixtures/AddedLine/base/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.36.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.1.5" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="NodaTime" Version="$(NodaTimeVersion)" />
     <PackageVersion Include="NodaTime.Testing" Version="$(NodaTimeVersion)" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />

--- a/tests/fixtures/AddedLine/patch/Directory.Packages.props
+++ b/tests/fixtures/AddedLine/patch/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.36.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.1.5" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="NodaTime" Version="$(NodaTimeVersion)" />
     <PackageVersion Include="NodaTime.Testing" Version="$(NodaTimeVersion)" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />

--- a/tests/fixtures/AddedLine/target/Directory.Packages.props
+++ b/tests/fixtures/AddedLine/target/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.36.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.1.5" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />

--- a/tests/fixtures/Complex/base/Directory.Packages.props
+++ b/tests/fixtures/Complex/base/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />

--- a/tests/fixtures/Complex/patch/Directory.Packages.props
+++ b/tests/fixtures/Complex/patch/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />

--- a/tests/fixtures/Complex/target/Directory.Packages.props
+++ b/tests/fixtures/Complex/target/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0-preview.6.23329.7" />
     <PackageVersion Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="Refit" Version="7.0.0" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />

--- a/tests/fixtures/Uneven/base/Directory.Packages.props
+++ b/tests/fixtures/Uneven/base/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="7.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" Condition=" '$(IsTestProject)' != 'true' " />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" Condition=" '$(IsTestProject)' == 'true' " />
     <PackageVersion Include="Polly" Version="7.2.4" />

--- a/tests/fixtures/Uneven/patch/Directory.Packages.props
+++ b/tests/fixtures/Uneven/patch/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="7.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" Condition=" '$(IsTestProject)' != 'true' " />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" Condition=" '$(IsTestProject)' == 'true' " />
     <PackageVersion Include="Polly" Version="7.2.4" />

--- a/tests/fixtures/Uneven/target/Directory.Packages.props
+++ b/tests/fixtures/Uneven/target/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0-preview.6.23329.7" />
     <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="8.0.0-preview.6.23329.11" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="MockingLibrary" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" Condition=" '$(IsTestProject)' != 'true' " />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" Condition=" '$(IsTestProject)' == 'true' " />
     <PackageVersion Include="Polly" Version="7.2.4" />


### PR DESCRIPTION
Update test cases to use a value other than `Moq` so GitHub code search doesn't flag up usages that aren't really there.
