### PR TITLE
Run check-dist on PRs only

### DIFF
--- a/.github/workflows/check-dist-failed.yml
+++ b/.github/workflows/check-dist-failed.yml
@@ -24,16 +24,18 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const { owner, repo } = context.repo;
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               commit_sha: context.payload.workflow_run.head_sha,
             });
             if (prs.length > 0) {
+              const pr = prs[0];
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prs[0].number,
-                body: `Hi @${prs[0].user.login} :wave:\n\nIt looks like this pull request makes changes which require the contents of \`dist\` to be updated, but these files have not been included with your changes.\n\nPlease run \`build.ps1\` and commit the changes made to the \`dist\` directory to your branch and push them to this pull request.`,
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: `Hi @${pr.user.login} :wave:\n\nIt looks like this pull request makes changes which require the contents of \`dist\` to be updated, but these files have not been included with your changes.\n\nPlease run \`build.ps1\` and commit the changes made to the \`dist\` directory to your branch and push them to this pull request.`,
               });
             }

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,12 +1,6 @@
 name: check-dist
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
-      - 'src/**'
   pull_request:
     branches: [ main ]
     paths:
@@ -20,7 +14,7 @@ permissions:
 
 jobs:
   check-dist:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -64,7 +58,7 @@ jobs:
 
       - name: Upload generated dist
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
+        if: failure() && steps.diff.conclusion == 'failure'
         with:
           name: dist
           path: dist/

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -12,7 +12,7 @@ jobs:
   tag:
     name: tag
     runs-on: [ ubuntu-latest ]
-    if: ${{ github.event.repository.fork == false }}
+    if: github.event.repository.fork == false
 
     permissions:
       contents: write


### PR DESCRIPTION
- Only run `check-dist` on pull requests.
- Simplify some JavaScript.
- Remove some redundant escaping.
