### PR TITLE
Remove redundant line

### DIFF
--- a/.github/workflows/check-dist-failed.yml
+++ b/.github/workflows/check-dist-failed.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Add comment
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({


### PR DESCRIPTION
`GITHUB_TOKEN` is the default anyway.
