### PR TITLE
Fix false vulnerability

### DIFF
--- a/tests/fixtures/package.json/base/package-lock.json
+++ b/tests/fixtures/package.json/base/package-lock.json
@@ -20,7 +20,7 @@
         "eventsource": "^2.0.2",
         "fetch-cookie": "^2.0.3",
         "node-fetch": "^2.6.7",
-        "ws": "^7.4.5"
+        "ws": "^7.5.10"
       }
     },
     "node_modules/abort-controller": {

--- a/tests/fixtures/package.json/patch/package-lock.json
+++ b/tests/fixtures/package.json/patch/package-lock.json
@@ -20,7 +20,7 @@
         "eventsource": "^2.0.2",
         "fetch-cookie": "^2.0.3",
         "node-fetch": "^2.6.7",
-        "ws": "^7.4.5"
+        "ws": "^7.5.10"
       }
     },
     "node_modules/abort-controller": {

--- a/tests/fixtures/package.json/target/package-lock.json
+++ b/tests/fixtures/package.json/target/package-lock.json
@@ -20,7 +20,7 @@
         "eventsource": "^2.0.2",
         "fetch-cookie": "^2.0.3",
         "node-fetch": "^2.6.7",
-        "ws": "^7.4.5"
+        "ws": "^7.5.10"
       }
     },
     "node_modules/abort-controller": {


### PR DESCRIPTION
Fix false-positive vulnerability alert for GHSA-3h5v-q93c-6h6q due to use in test asset lock file.
