### PR TITLE
Skip check-dist for renovate

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   check-dist:
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Do not run `check-dist` for Renovate PRs.
