### PR TITLE
Refactor secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ permissions: {}
 
 jobs:
   build:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os-name }}
     runs-on: ${{ matrix.os }}
 
     permissions:
@@ -29,11 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          # renovate: datasource=github-runners depType=github-runner
+          - os: macos-26
             os-name: macos
-          - os: ubuntu-latest
+          # renovate: datasource=github-runners depType=github-runner
+          - os: ubuntu-24.04
             os-name: linux
-          - os: windows-latest
+          # renovate: datasource=github-runners depType=github-runner
+          - os: windows-2025
             os-name: windows
 
     steps:
@@ -61,7 +64,6 @@ jobs:
       name: Upload coverage to Codecov
       with:
         flags: ${{ matrix.os-name }}
-        token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Generate SBOM
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
@@ -80,7 +82,7 @@ jobs:
         subject-path: ./dist/**/*.js
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       actions: read

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,13 +15,28 @@ permissions: {}
 
 jobs:
   bump-version:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
+    if: github.event.repository.fork == false
 
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
 
+    environment:
+      name: write
+      deployment: false
+
+    permissions:
+      id-token: write
+
     steps:
+
+      - name: Get GitHub token
+        id: get-github-token
+        # zizmor: ignore[ref-version-mismatch] False positive
+        uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+        with:
+          profile-name: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -29,7 +44,7 @@ jobs:
           filter: 'tree:0'
           persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          token: ${{ steps.get-github-token.outputs.token }}
 
       - name: Bump version
         id: bump-version
@@ -57,7 +72,7 @@ jobs:
           $json.packages.''.version = $updatedVersion
           $json | ConvertTo-Json -Depth 32 | Set-Content $fileName
 
-          "version=${updatedVersion}" >> $env:GITHUB_OUTPUT
+          "version=${updatedVersion}" >> ${env:GITHUB_OUTPUT}
 
       - name: Push changes to GitHub
         id: push-changes
@@ -93,9 +108,9 @@ jobs:
           git commit -m "Bump version`n`nBump version to ${env:NEXT_VERSION} for the next release." -s
           git push -u origin $branchName
 
-          "branch-name=${branchName}" >> $env:GITHUB_OUTPUT
-          "updated-version=true" >> $env:GITHUB_OUTPUT
-          "version=${env:NEXT_VERSION}" >> $env:GITHUB_OUTPUT
+          "branch-name=${branchName}" >> ${env:GITHUB_OUTPUT}
+          "updated-version=true" >> ${env:GITHUB_OUTPUT}
+          "version=${env:NEXT_VERSION}" >> ${env:GITHUB_OUTPUT}
 
       - name: Create pull request
         if: steps.push-changes.outputs.updated-version == 'true'
@@ -105,7 +120,7 @@ jobs:
           HEAD_BRANCH: ${{ steps.push-changes.outputs.branch-name }}
           NEXT_VERSION: ${{ steps.push-changes.outputs.version }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const nextVersion = process.env.NEXT_VERSION;
             const { repo, owner } = context.repo;
@@ -117,7 +132,7 @@ jobs:
               repo,
               head: process.env.HEAD_BRANCH,
               base: process.env.BASE_BRANCH,
-              draft: true,
+              draft: false,
               body: [
                 `Bump version to \`${nextVersion}\` for the next release.`,
                 '',
@@ -157,12 +172,15 @@ jobs:
             }
 
   close-milestone:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release'
 
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
+
+    permissions:
+      issues: write
 
     steps:
 
@@ -172,7 +190,7 @@ jobs:
           RELEASE_DATE: ${{ github.event.release.published_at }}
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { repo, owner } = context.repo;
 

--- a/.github/workflows/check-dist-failed.yml
+++ b/.github/workflows/check-dist-failed.yml
@@ -13,7 +13,7 @@ jobs:
       github.event.repository.fork == false &&
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       pull-requests: write

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   check-dist:
     if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]"]'), github.event.pull_request.user.login) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       actions: read
@@ -51,7 +51,7 @@ jobs:
   codeql:
     if: ${{ !cancelled() }}
     needs: [ analysis ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Report status

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -7,13 +7,28 @@ permissions: {}
 
 jobs:
   regenerate:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
+    if: github.event.repository.fork == false
 
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
 
+    environment:
+      name: write
+      deployment: false
+
+    permissions:
+      id-token: write
+
     steps:
+
+      - name: Get GitHub token
+        id: get-github-token
+        # zizmor: ignore[ref-version-mismatch] False positive
+        uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+        with:
+          profile-name: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -21,7 +36,7 @@ jobs:
           filter: 'tree:0'
           persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          token: ${{ steps.get-github-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -74,8 +89,8 @@ jobs:
 
           git push -u origin $branchName
 
-          "branch-name=${branchName}" >> $env:GITHUB_OUTPUT
-          "regenerated=true" >> $env:GITHUB_OUTPUT
+          "branch-name=${branchName}" >> ${env:GITHUB_OUTPUT}
+          "regenerated=true" >> ${env:GITHUB_OUTPUT}
 
       - name: Create pull request
         if: steps.push-changes.outputs.regenerated == 'true'
@@ -84,7 +99,7 @@ jobs:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
           HEAD_BRANCH: ${{ steps.push-changes.outputs.branch-name }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const { repo, owner } = context.repo;
             const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -13,7 +13,7 @@ permissions: read-all # zizmor: ignore[excessive-permissions] Recommended permis
 jobs:
   analysis:
     name: analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       id-token: write

--- a/.github/workflows/regenerate-dist.yml
+++ b/.github/workflows/regenerate-dist.yml
@@ -13,13 +13,28 @@ permissions: {}
 
 jobs:
   regenerate:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
+    if: github.event.repository.fork == false
 
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
 
+    environment:
+      name: write
+      deployment: false
+
+    permissions:
+      id-token: write
+
     steps:
+
+      - name: Get GitHub token
+        id: get-github-token
+        # zizmor: ignore[ref-version-mismatch] False positive
+        uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+        with:
+          profile-name: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,7 +42,7 @@ jobs:
           filter: 'tree:0'
           persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          token: ${{ steps.get-github-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -81,8 +96,8 @@ jobs:
 
           git push -u origin $branchName
 
-          "branch-name=${branchName}" >> $env:GITHUB_OUTPUT
-          "regenerated=true" >> $env:GITHUB_OUTPUT
+          "branch-name=${branchName}" >> ${env:GITHUB_OUTPUT}
+          "regenerated=true" >> ${env:GITHUB_OUTPUT}
 
       - name: Create pull request
         if: steps.push-changes.outputs.regenerated == 'true'
@@ -91,7 +106,7 @@ jobs:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
           HEAD_BRANCH: ${{ steps.push-changes.outputs.branch-name }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const { repo, owner } = context.repo;
             const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,20 @@ permissions: {}
 
 jobs:
   release:
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
+    if: github.event.repository.fork == false
 
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
+
+    environment:
+      name: release
+      deployment: false
+
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
 
@@ -25,9 +34,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           filter: 'tree:0'
-          persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+          persist-credentials: false
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
 
       - name: Get version
         id: get-version
@@ -36,7 +44,14 @@ jobs:
           $fileName = Join-Path "." "package.json"
           $json = (Get-Content $fileName | Out-String | ConvertFrom-Json)
           $version = $json.version
-          "version=${version}" >> $env:GITHUB_OUTPUT
+          "version=${version}" >> ${env:GITHUB_OUTPUT}
+
+      - name: Get GitHub token
+        id: get-github-token
+        # zizmor: ignore[ref-version-mismatch] False positive
+        uses: martincostello/github-automation/actions/get-github-token@16711f5c6f94e59ee14b83697acb675be1528856 # get-github-token/v4.1.0
+        with:
+          profile-name: release
 
       - name: Create release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -45,7 +60,7 @@ jobs:
           DRAFT: ${{ inputs.publish != true }}
           VERSION: ${{ steps.get-version.outputs.version }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const { repo, owner } = context.repo;
             const draft = process.env.DRAFT === 'true';

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   tag:
     name: tag
-    runs-on: [ ubuntu-latest ]
+    runs-on: ubuntu-24.04
     if: github.event.repository.fork == false
 
     permissions:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,7 +5,5 @@ rules:
     disable: true
   dependabot-cooldown:
     disable: true
-  secrets-outside-env:
-    disable: true
   undocumented-permissions:
     disable: true


### PR DESCRIPTION
- Use GitHub token broker instead of `COSTELLOBOT_TOKEN`.
- Remove `CODECOV_TOKEN`.
- Remove redundant credentials usage.
- Use version-specific GItHub runner labels.
- Use consistent PowerShell env var syntax.
- Enable `secrets-outside-env` for zizmor.
- Do not create version bump PRs as drafts.
